### PR TITLE
feat: implement new chart

### DIFF
--- a/frontend/components/coin-details/coin-history-chart-card.tsx
+++ b/frontend/components/coin-details/coin-history-chart-card.tsx
@@ -1,124 +1,176 @@
-import { type ReactNode, useMemo } from "react";
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis
-} from "recharts";
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
 
+import type { CoinHistoryChartFilters } from "@/hooks/coin-details-view/coin-history-view-types";
 import type { CoinHistoryEntry } from "@/types/coins";
 import { formatUsdCompact, formatUsdPrice } from "@/utils/coin-formatters";
+import {
+  BRAND,
+  FILTERED_OUT,
+  GRID,
+  MUTED,
+  TEXT,
+  TOOLTIP_BG,
+  TOOLTIP_BORDER,
+  defaultDataZoom,
+  tickFormatter
+} from "@/utils/chart-theme";
 
 interface CoinHistoryChartCardProps {
   entries: CoinHistoryEntry[];
+  chartFilters: CoinHistoryChartFilters;
 }
 
-interface CoinHistoryChartPoint {
-  timestamp: string;
-  priceUsd: number;
-}
+const tooltipFormatter = new Intl.DateTimeFormat("ru-RU", { dateStyle: "medium", timeStyle: "short" });
 
-const chartTickFormatter = new Intl.DateTimeFormat("ru-RU", {
-  day: "numeric",
-  month: "short"
-});
+const formatPriceTick = (value: number): string =>
+  Math.abs(value) >= 1000 ? formatUsdCompact(value) : formatUsdPrice(value);
 
-const chartTooltipFormatter = new Intl.DateTimeFormat("ru-RU", {
-  dateStyle: "medium",
-  timeStyle: "short"
-});
+export const CoinHistoryChartCard = ({ entries, chartFilters }: CoinHistoryChartCardProps) => {
+  const derived = useMemo(() => {
+    const sorted = [...entries].sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
 
-const formatChartPriceTick = (value: number): string => {
-  if (Math.abs(value) >= 1000) {
-    return formatUsdCompact(value);
-  }
+    if (sorted.length === 0) return null;
 
-  return formatUsdPrice(value);
-};
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
 
-const formatTooltipPrice = (value: unknown): string => {
-  const normalizedValue = Array.isArray(value) ? value[0] : value;
-  const numericValue =
-    typeof normalizedValue === "number"
-      ? normalizedValue
-      : typeof normalizedValue === "string"
-        ? Number(normalizedValue)
-        : null;
-
-  return typeof numericValue === "number" && Number.isFinite(numericValue)
-    ? formatUsdPrice(numericValue)
-    : formatUsdPrice(null);
-};
-
-const formatTooltipLabel = (value: ReactNode): string =>
-  chartTooltipFormatter.format(new Date(String(value)));
-
-export const CoinHistoryChartCard = ({ entries }: CoinHistoryChartCardProps) => {
-  const chartState = useMemo(() => {
-    const points = [...entries]
-      .sort((leftEntry, rightEntry) => {
-        const leftTime = new Date(leftEntry.timestamp).getTime();
-        const rightTime = new Date(rightEntry.timestamp).getTime();
-
-        return leftTime - rightTime;
-      })
-      .map<CoinHistoryChartPoint>((entry) => ({
-        timestamp: entry.timestamp,
-        priceUsd: entry.priceUsd
-      }));
-
-    let minPriceUsd = Number.POSITIVE_INFINITY;
-    let maxPriceUsd = Number.NEGATIVE_INFINITY;
-
-    for (const point of points) {
-      if (point.priceUsd < minPriceUsd) {
-        minPriceUsd = point.priceUsd;
-      }
-
-      if (point.priceUsd > maxPriceUsd) {
-        maxPriceUsd = point.priceUsd;
-      }
+    for (const p of sorted) {
+      if (p.priceUsd < min) min = p.priceUsd;
+      if (p.priceUsd > max) max = p.priceUsd;
     }
+
+    const padding = min === max ? Math.abs(min) * 0.05 : (max - min) * 0.05;
+    const prices = sorted.map((p) => p.priceUsd);
+
+    const hasFilters =
+      chartFilters.priceMin !== null ||
+      chartFilters.priceMax !== null ||
+      chartFilters.volumeMin !== null ||
+      chartFilters.volumeMax !== null;
+
+    const filteredPrices = hasFilters
+      ? sorted.map((entry) => {
+          const ok =
+            (chartFilters.priceMin === null || entry.priceUsd >= chartFilters.priceMin) &&
+            (chartFilters.priceMax === null || entry.priceUsd <= chartFilters.priceMax) &&
+            (chartFilters.volumeMin === null || entry.volume24hUsd >= chartFilters.volumeMin) &&
+            (chartFilters.volumeMax === null || entry.volume24hUsd <= chartFilters.volumeMax);
+          return ok ? entry.priceUsd : null;
+        })
+      : null;
+
+    const series = hasFilters
+      ? [
+          {
+            type: "line",
+            data: prices,
+            showSymbol: false,
+            lineStyle: { color: FILTERED_OUT, width: 1.5, type: "dashed" },
+            itemStyle: { color: FILTERED_OUT },
+            z: 1
+          },
+          {
+            type: "line",
+            data: filteredPrices,
+            connectNulls: false,
+            showSymbol: false,
+            lineStyle: { color: BRAND, width: 3 },
+            itemStyle: { color: BRAND },
+            z: 2
+          }
+        ]
+      : [
+          {
+            type: "line",
+            data: prices,
+            showSymbol: false,
+            lineStyle: { color: BRAND, width: 3 },
+            itemStyle: { color: BRAND }
+          }
+        ];
+
+    const axisLabel = { color: MUTED, fontSize: 12 };
+
+    const option = {
+      grid: { top: 8, right: 12, bottom: 52, left: 8, containLabel: true },
+      xAxis: {
+        type: "category",
+        data: sorted.map((p) => p.timestamp),
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: {
+          ...axisLabel,
+          formatter: (value: string) => tickFormatter.format(new Date(value))
+        }
+      },
+      yAxis: {
+        type: "value",
+        min: min - padding,
+        max: max + padding,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { ...axisLabel, formatter: formatPriceTick },
+        splitLine: { lineStyle: { color: GRID, type: "dashed" } }
+      },
+      tooltip: {
+        trigger: "axis",
+        backgroundColor: TOOLTIP_BG,
+        borderColor: TOOLTIP_BORDER,
+        borderRadius: 18,
+        textStyle: { color: TEXT, fontSize: 13 },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        formatter: (params: any[]) => {
+          const p = params[0];
+          if (!p) return "";
+          return `${tooltipFormatter.format(new Date(String(p.axisValue)))}<br/><b>${formatUsdPrice(Number(p.value))}</b>`;
+        }
+      },
+      dataZoom: defaultDataZoom,
+      series
+    };
 
     return {
-      points,
-      latestPriceUsd: points.at(-1)?.priceUsd ?? null,
-      minPriceUsd: Number.isFinite(minPriceUsd) ? minPriceUsd : null,
-      maxPriceUsd: Number.isFinite(maxPriceUsd) ? maxPriceUsd : null
+      option,
+      hasFilters,
+      summaryMetrics: [
+        { label: "Последняя цена", value: formatUsdPrice(sorted.at(-1)!.priceUsd) },
+        { label: "Мин. за период", value: formatUsdPrice(min) },
+        { label: "Макс. за период", value: formatUsdPrice(max) }
+      ]
     };
-  }, [entries]);
+  }, [entries, chartFilters.priceMin, chartFilters.priceMax, chartFilters.volumeMin, chartFilters.volumeMax]);
 
-  if (chartState.points.length === 0) {
-    return null;
-  }
+  if (!derived) return null;
 
-  const summaryMetrics = [
-    {
-      label: "Последняя цена",
-      value: formatUsdPrice(chartState.latestPriceUsd)
-    },
-    {
-      label: "Мин. на странице",
-      value: formatUsdPrice(chartState.minPriceUsd)
-    },
-    {
-      label: "Макс. на странице",
-      value: formatUsdPrice(chartState.maxPriceUsd)
-    }
-  ];
+  const { option, hasFilters, summaryMetrics } = derived;
 
   return (
     <section className="cw-surface-soft">
       <div className="flex flex-col gap-4 border-b border-dashed border-border pb-5 xl:flex-row xl:items-end xl:justify-between">
         <div className="min-w-0">
           <p className="cw-kicker">График цены</p>
-          <h3 className="cw-card-title mt-3">Динамика по текущим записям</h3>
-          <p className="mt-2 text-sm text-text-muted">
-            График строится по тем же строкам, которые показаны в таблице ниже
-          </p>
+          <h3 className="cw-card-title mt-3">Динамика за период</h3>
+          {hasFilters && (
+            <div className="mt-2 flex gap-4 text-xs text-text-muted">
+              <span className="flex items-center gap-1.5">
+                <span
+                  className="inline-block h-px w-4"
+                  style={{ borderBottom: `1px dashed ${FILTERED_OUT}` }}
+                />
+                Вне фильтра
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span
+                  className="inline-block h-0.5 w-4 rounded"
+                  style={{ backgroundColor: BRAND }}
+                />
+                В фильтре
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
@@ -132,51 +184,7 @@ export const CoinHistoryChartCard = ({ entries }: CoinHistoryChartCardProps) => 
       </div>
 
       <div className="mt-6 h-80 w-full">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartState.points} margin={{ top: 8, right: 12, bottom: 8, left: 0 }}>
-            <CartesianGrid stroke="rgba(209, 213, 219, 0.6)" strokeDasharray="3 6" vertical={false} />
-            <XAxis
-              axisLine={false}
-              dataKey="timestamp"
-              minTickGap={24}
-              tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
-              tickFormatter={(value: string) => chartTickFormatter.format(new Date(value))}
-              tickLine={false}
-            />
-            <YAxis
-              axisLine={false}
-              tick={{ fill: "var(--color-text-muted)", fontSize: 12 }}
-              tickFormatter={(value: number) => formatChartPriceTick(value)}
-              tickLine={false}
-              width={88}
-            />
-            <Tooltip
-              contentStyle={{
-                border: "1px solid var(--border-soft)",
-                borderRadius: "18px",
-                boxShadow: "var(--shadow-panel)",
-                backgroundColor: "rgba(255, 255, 255, 0.96)"
-              }}
-              cursor={{ stroke: "rgba(124, 58, 237, 0.24)", strokeWidth: 1 }}
-              formatter={formatTooltipPrice}
-              labelFormatter={formatTooltipLabel}
-            />
-            <Line
-              activeDot={{ r: 5 }}
-              dataKey="priceUsd"
-              dot={{
-                r: 3,
-                stroke: "var(--color-brand)",
-                strokeWidth: 2,
-                fill: "var(--color-surface)"
-              }}
-              name="Цена"
-              stroke="var(--color-brand)"
-              strokeWidth={3}
-              type="monotone"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <ReactECharts option={option} style={{ height: "100%", width: "100%" }} />
       </div>
     </section>
   );

--- a/frontend/components/coin-details/coin-history-section.tsx
+++ b/frontend/components/coin-details/coin-history-section.tsx
@@ -68,7 +68,7 @@ export const CoinHistorySection = ({ viewState }: CoinHistorySectionProps) => {
           <h2 className="cw-card-title">Фильтры, график и записи</h2>
         </div>
 
-        <div className="cw-panel-muted">
+        <form className="cw-panel-muted" onSubmit={(e) => { e.preventDefault(); viewState.filters.onApply(); }} onKeyDown={(e) => { if (e.key === "Enter" && (e.target as HTMLInputElement).type === "date") e.currentTarget.requestSubmit(); }}>
           <div className="cw-filter-grid">
             <RangeField
               id="coin-history-date"
@@ -119,8 +119,7 @@ export const CoinHistorySection = ({ viewState }: CoinHistorySectionProps) => {
             <div className="cw-toolbar-actions">
               <button
                 className="cw-button-primary"
-                type="button"
-                onClick={viewState.filters.onApply}
+                type="submit"
                 disabled={viewState.filters.isApplyDisabled}
               >
                 {viewState.filters.isApplyPending ? "Применяем..." : "Применить"}
@@ -135,7 +134,7 @@ export const CoinHistorySection = ({ viewState }: CoinHistorySectionProps) => {
               </button>
             </div>
           </div>
-        </div>
+        </form>
       </div>
 
       <ViewStateSection
@@ -153,7 +152,7 @@ export const CoinHistorySection = ({ viewState }: CoinHistorySectionProps) => {
         }}
       >
         <div className="space-y-4">
-          <CoinHistoryChartCard entries={viewState.entries} />
+          <CoinHistoryChartCard entries={viewState.chartEntries} chartFilters={viewState.chartFilters} />
 
           <div className="cw-table-wrap">
             <table className="cw-table">

--- a/frontend/hooks/coin-details-view/coin-history-view-types.ts
+++ b/frontend/hooks/coin-details-view/coin-history-view-types.ts
@@ -27,8 +27,17 @@ export interface CoinHistoryFiltersViewState {
   onReset: () => void;
 }
 
+export interface CoinHistoryChartFilters {
+  priceMin: number | null;
+  priceMax: number | null;
+  volumeMin: number | null;
+  volumeMax: number | null;
+}
+
 export interface UseCoinHistoryViewResult {
   entries: CoinHistoryEntry[];
+  chartEntries: CoinHistoryEntry[];
+  chartFilters: CoinHistoryChartFilters;
   errorMessage: string;
   filters: CoinHistoryFiltersViewState;
   pagination: CoinTablePagination;

--- a/frontend/hooks/coin-details-view/use-coin-history-view.ts
+++ b/frontend/hooks/coin-details-view/use-coin-history-view.ts
@@ -7,6 +7,7 @@ import {
   getCoinRouteSymbol
 } from "@/hooks/coin-details-view/coin-details-route";
 import type {
+  CoinHistoryChartFilters,
   CoinHistoryFiltersDraft,
   UseCoinHistoryViewResult
 } from "@/hooks/coin-details-view/coin-history-view-types";
@@ -22,6 +23,7 @@ import {
 
 const DEFAULT_HISTORY_PAGE_SIZE = 10;
 const DEFAULT_HISTORY_RANGE_DAYS = 7;
+const CHART_PAGE_SIZE = 2000;
 
 interface CoinHistoryRouteAppliedState {
   filters: CoinHistoryFiltersDraft;
@@ -190,6 +192,17 @@ const buildHistoryRequestParams = (state: CoinHistoryRouteAppliedState) => ({
   pageSize: DEFAULT_HISTORY_PAGE_SIZE
 });
 
+const buildChartRequestParams = (state: CoinHistoryRouteAppliedState) => ({
+  dateFrom: state.filters.dateFrom
+    ? toDateBoundaryIso(state.filters.dateFrom, "start")
+    : undefined,
+  dateTo: state.filters.dateTo ? toDateBoundaryIso(state.filters.dateTo, "end") : undefined,
+  pageNo: 0,
+  pageSize: CHART_PAGE_SIZE,
+  sortBy: "timestamp" as const,
+  order: "asc" as const
+});
+
 const getHistoryTotalLabel = (
   currentPage: number,
   pageSize: number,
@@ -220,10 +233,12 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
       };
   const [draftFilters, setDraftFilters] = useState<CoinHistoryFiltersDraft>(defaultDraft);
   const [entries, setEntries] = useState<UseCoinHistoryViewResult["entries"]>([]);
+  const [chartEntries, setChartEntries] = useState<UseCoinHistoryViewResult["chartEntries"]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [status, setStatus] = useState<UseCoinHistoryViewResult["status"]>(VIEW_STATUS.LOADING);
   const [errorMessage, setErrorMessage] = useState("Не удалось загрузить историю");
-  const latestRequestIdRef = useRef(0);
+  const latestTableRequestIdRef = useRef(0);
+  const latestChartRequestIdRef = useRef(0);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -300,13 +315,17 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
     ]
   );
 
-  const loadHistory = useCallback(async () => {
+  const chartRequestParams = useMemo(
+    () => buildChartRequestParams(appliedState),
+    [appliedState.filters.dateFrom, appliedState.filters.dateTo]
+  );
+
+  const loadTableData = useCallback(async () => {
     if (!router.isReady || !symbol) {
       return;
     }
 
-    const requestId = latestRequestIdRef.current + 1;
-    latestRequestIdRef.current = requestId;
+    const requestId = ++latestTableRequestIdRef.current;
 
     setStatus(VIEW_STATUS.LOADING);
     setEntries([]);
@@ -316,7 +335,7 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
     try {
       const response = await coinsService.getCoinHistory(symbol, requestParams);
 
-      if (!isMountedRef.current || latestRequestIdRef.current !== requestId) {
+      if (!isMountedRef.current || latestTableRequestIdRef.current !== requestId) {
         return;
       }
 
@@ -324,7 +343,7 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
       setTotalCount(response.totalCount);
       setStatus(response.totalCount === 0 ? VIEW_STATUS.EMPTY : VIEW_STATUS.READY);
     } catch (error) {
-      if (!isMountedRef.current || latestRequestIdRef.current !== requestId) {
+      if (!isMountedRef.current || latestTableRequestIdRef.current !== requestId) {
         return;
       }
 
@@ -335,9 +354,43 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
     }
   }, [requestParams, router.isReady, symbol]);
 
+  const loadChartData = useCallback(async () => {
+    if (!router.isReady || !symbol) {
+      return;
+    }
+
+    const requestId = ++latestChartRequestIdRef.current;
+
+    setChartEntries([]);
+
+    try {
+      const response = await coinsService.getCoinHistory(symbol, chartRequestParams);
+
+      if (!isMountedRef.current || latestChartRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setChartEntries(response.history);
+    } catch {
+      if (!isMountedRef.current || latestChartRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setChartEntries([]);
+    }
+  }, [chartRequestParams, router.isReady, symbol]);
+
+  const retry = useCallback(async () => {
+    await Promise.all([loadTableData(), loadChartData()]);
+  }, [loadTableData, loadChartData]);
+
   useEffect(() => {
-    void loadHistory();
-  }, [loadHistory]);
+    void loadTableData();
+  }, [loadTableData]);
+
+  useEffect(() => {
+    void loadChartData();
+  }, [loadChartData]);
 
   const replaceAppliedState = useCallback(
     (nextState: CoinHistoryRouteAppliedState) => {
@@ -366,8 +419,17 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
     isRouteTransitionPending;
   const totalPages = Math.max(1, Math.ceil(totalCount / DEFAULT_HISTORY_PAGE_SIZE));
 
+  const chartFilters: CoinHistoryChartFilters = {
+    priceMin: parseCoinFilterNumber(appliedState.filters.priceMin),
+    priceMax: parseCoinFilterNumber(appliedState.filters.priceMax),
+    volumeMin: parseCoinFilterNumber(appliedState.filters.volumeMin),
+    volumeMax: parseCoinFilterNumber(appliedState.filters.volumeMax)
+  };
+
   return {
     entries,
+    chartEntries,
+    chartFilters,
     errorMessage,
     filters: {
       draft: draftFilters,
@@ -455,7 +517,7 @@ export const useCoinHistoryView = (): UseCoinHistoryViewResult => {
       },
       isPending: isRouteTransitionPending
     },
-    retry: loadHistory,
+    retry,
     status,
     totalLabel: getHistoryTotalLabel(
       appliedState.page,

--- a/frontend/hooks/statistics-view/use-statistics-view.ts
+++ b/frontend/hooks/statistics-view/use-statistics-view.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useStatisticsParams } from "@/hooks/statistics-view/use-statistics-params";
 import { useStatisticsPresets } from "@/hooks/statistics-view/use-statistics-presets";
 import { useStatisticsResults } from "@/hooks/statistics-view/use-statistics-results";
-import type { AggregatedDataPoint, StatisticsPreset } from "@/types/statistics";
+import type { StatisticsPreset } from "@/types/statistics";
 
 export type ChartMetric = "avgPrice" | "minPrice" | "maxPrice" | "avgVolume";
 
@@ -16,17 +16,8 @@ const loadSavedMetric = (): ChartMetric => {
   return "avgPrice";
 };
 
-const toShortDate = (timestamp: number): string =>
-  new Date(timestamp).toLocaleDateString("ru-RU", { day: "numeric", month: "short" });
-
 const toDateInputValue = (timestamp: number): string =>
   new Date(timestamp).toISOString().slice(0, 10);
-
-const computeLabels = (points: AggregatedDataPoint[]): string[] => {
-  if (points.length <= 6) return points.map((p) => toShortDate(p.periodStart));
-  const step = Math.floor(points.length / 5);
-  return points.filter((_, i) => i % step === 0).map((p) => toShortDate(p.periodStart));
-};
 
 export const useStatisticsView = () => {
   const params = useStatisticsParams();
@@ -43,9 +34,13 @@ export const useStatisticsView = () => {
   const data = results.result?.data;
   const firstSymbolPoints = symbols[0] ? (data?.[symbols[0]] ?? []) : [];
 
-  const chartMaxValue = Math.max(...firstSymbolPoints.map((p) => p[chartMetric]), 1);
-  const chartBars = firstSymbolPoints.map((p) => Math.round((p[chartMetric] / chartMaxValue) * 100));
-  const chartLabels = computeLabels(firstSymbolPoints);
+  const chartValues = firstSymbolPoints.map((p) => p[chartMetric]);
+  const chartTimestamps = firstSymbolPoints.map((p) => p.periodStart);
+
+  const dateValidationMessage =
+    params.timeRangeFrom && params.timeRangeTo && params.timeRangeFrom > params.timeRangeTo
+      ? "Поле «Период»: значение «от» не должно быть больше значения «до»"
+      : null;
 
   const build = useCallback(
     () => results.build(params.currentParams),
@@ -74,12 +69,12 @@ export const useStatisticsView = () => {
     params,
     results,
     presets,
-    chartBars,
-    chartLabels,
-    chartMaxValue,
+    chartValues,
+    chartTimestamps,
     chartMetric,
     setChartMetric,
     selectedSymbols: symbols,
+    dateValidationMessage,
     build,
     retry,
     loadPreset

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,12 @@
       "name": "cryptowatch-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "next": "15.2.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "react-is": "^19.2.5",
-        "recharts": "^3.8.1"
+        "react-is": "^19.2.5"
       },
       "devDependencies": {
         "@types/node": "22.13.14",
@@ -928,42 +929,6 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -976,18 +941,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -1015,69 +968,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1114,7 +1004,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1129,12 +1019,6 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -2316,15 +2200,6 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2419,129 +2294,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2621,12 +2375,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2722,6 +2470,36 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
@@ -2913,16 +2691,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
-      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3355,17 +3123,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3812,16 +3573,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3862,15 +3613,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5281,29 +5023,6 @@
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5325,51 +5044,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/recharts": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
-      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5415,12 +5089,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -5772,6 +5440,12 @@
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -6167,12 +5841,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6480,43 +6148,12 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6661,6 +6298,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "next": "15.2.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-is": "^19.2.5",
-    "recharts": "^3.8.1"
+    "react-is": "^19.2.5"
   },
   "devDependencies": {
     "@types/node": "22.13.14",

--- a/frontend/pages/app/statistics.tsx
+++ b/frontend/pages/app/statistics.tsx
@@ -1,24 +1,64 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import ReactECharts from "echarts-for-react";
 import { AppPageShell } from "@/components/app-page-shell";
 import { RangeField } from "@/components/coins/range-field";
 import { ViewStateSection } from "@/components/view-state/view-state-section";
 import { useStatisticsView } from "@/hooks/statistics-view/use-statistics-view";
 import type { ChartMetric } from "@/hooks/statistics-view/use-statistics-view";
 import type { StatisticsPreset } from "@/types/statistics";
+import { BRAND, GRID, MUTED, TEXT, TOOLTIP_BG, TOOLTIP_BORDER, defaultDataZoom, tickFormatter } from "@/utils/chart-theme";
+
+const formatValue = (value: number, metric: ChartMetric): string => {
+  const prefix = metric === "avgVolume" ? "" : "$";
+  if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(0)}k`;
+  return `${prefix}${value.toFixed(0)}`;
+};
 
 const StatisticsPageContent = () => {
-  const { params, results, presets, chartBars, chartLabels, chartMaxValue, chartMetric, setChartMetric, selectedSymbols, build, retry, loadPreset } =
+  const { params, results, presets, chartValues, chartTimestamps, chartMetric, setChartMetric, selectedSymbols, dateValidationMessage, build, retry, loadPreset } =
     useStatisticsView();
 
-  const formatValue = (value: number, metric: ChartMetric): string => {
-    const isVolume = metric === "avgVolume";
-    const prefix = isVolume ? "" : "$";
-    const suffix = isVolume ? "" : "";
-    if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(1)}B${suffix}`;
-    if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(1)}M${suffix}`;
-    if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(0)}k${suffix}`;
-    return `${prefix}${value.toFixed(0)}${suffix}`;
-  };
+  const chartOption = useMemo(() => ({
+    grid: { top: 8, right: 12, bottom: 52, left: 8, containLabel: true },
+    xAxis: {
+      type: "category",
+      data: chartTimestamps.map((ts) => tickFormatter.format(new Date(ts))),
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: MUTED, fontSize: 11 }
+    },
+    yAxis: {
+      type: "value",
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: MUTED, fontSize: 11, formatter: (v: number) => formatValue(v, chartMetric) },
+      splitLine: { lineStyle: { color: GRID, type: "dashed" } }
+    },
+    tooltip: {
+      trigger: "axis",
+      backgroundColor: TOOLTIP_BG,
+      borderColor: TOOLTIP_BORDER,
+      borderRadius: 18,
+      textStyle: { color: TEXT, fontSize: 13 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      formatter: (params: any[]) => {
+        const p = params[0];
+        if (!p) return "";
+        return `${String(p.axisValue)}<br/><b>${formatValue(Number(p.value), chartMetric)}</b>`;
+      }
+    },
+    dataZoom: defaultDataZoom,
+    series: [
+      {
+        type: "bar",
+        data: chartValues,
+        itemStyle: { color: BRAND, borderRadius: [18, 18, 0, 0] },
+        barMaxWidth: 48
+      }
+    ]
+  }), [chartTimestamps, chartValues, chartMetric]);
 
   const [symbolsInput, setSymbolsInput] = useState(() => params.currentParams.symbols.join(", "));
   const [showSaveForm, setShowSaveForm] = useState(false);
@@ -51,7 +91,7 @@ const StatisticsPageContent = () => {
     >
       <section className="cw-toolbar">
         <div className="cw-toolbar-actions">
-          <button className="cw-button-primary" form="stats-params-form" type="submit">
+          <button className="cw-button-primary" form="stats-params-form" type="submit" disabled={!!dateValidationMessage}>
             Построить
           </button>
           <button
@@ -96,7 +136,7 @@ const StatisticsPageContent = () => {
 
       <section className="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1fr)_320px]">
         <div className="space-y-8">
-          <form id="stats-params-form" onSubmit={(e) => { e.preventDefault(); build(); }}>
+          <form id="stats-params-form" onSubmit={(e) => { e.preventDefault(); build(); }} onKeyDown={(e) => { if (e.key === "Enter" && (e.target as HTMLInputElement).type === "date") e.currentTarget.requestSubmit(); }}>
             <div className="cw-section-label">Параметры</div>
             <div className="cw-panel-muted">
               <div className="mb-6">
@@ -199,6 +239,9 @@ const StatisticsPageContent = () => {
                   </select>
                 </div>
               </div>
+              {dateValidationMessage && (
+                <p className="mt-4 text-sm cw-negative">{dateValidationMessage}</p>
+              )}
             </div>
           </form>
 
@@ -213,7 +256,7 @@ const StatisticsPageContent = () => {
               onRetry={retry}
             >
               <div className="cw-surface overflow-hidden px-5 py-5 sm:px-6">
-                <div className="mb-6 flex flex-wrap items-center gap-3">
+                <div className="mb-4 flex flex-wrap items-center gap-3">
                   {selectedSymbols.map((symbol) => (
                     <span key={symbol} className="cw-chip">
                       {symbol}
@@ -221,40 +264,8 @@ const StatisticsPageContent = () => {
                   ))}
                 </div>
 
-                <div className="cw-surface-soft relative">
-                  <div className="pointer-events-none absolute inset-y-6 left-12 right-6 flex flex-col justify-between">
-                    <div className="border-t border-dashed border-border"></div>
-                    <div className="border-t border-dashed border-border"></div>
-                    <div className="border-t border-dashed border-border"></div>
-                    <div className="border-t border-dashed border-border"></div>
-                  </div>
-
-                  <div className="absolute left-0 top-0 flex h-[280px] w-10 flex-col justify-between py-1 pr-1">
-                    {[1, 0.75, 0.5, 0.25, 0].map((pct) => (
-                      <span
-                        key={pct}
-                        className="block text-right text-[10px] leading-none text-text-muted"
-                      >
-                        {formatValue(chartMaxValue * pct, chartMetric)}
-                      </span>
-                    ))}
-                  </div>
-
-                  <div className="relative flex h-[280px] items-end gap-3 pl-10 pr-2">
-                    {chartBars.map((value, index) => (
-                      <div
-                        key={index}
-                        className="flex-1 rounded-t-[18px] bg-brand/80"
-                        style={{ height: `${value}%` }}
-                      />
-                    ))}
-                  </div>
-
-                  <div className="mt-5 flex justify-between pl-10 text-xs uppercase tracking-[0.14em] text-text-muted">
-                    {chartLabels.map((label) => (
-                      <span key={label}>{label}</span>
-                    ))}
-                  </div>
+                <div className="h-72 w-full">
+                  <ReactECharts option={chartOption} style={{ height: "100%", width: "100%" }} />
                 </div>
               </div>
             </ViewStateSection>

--- a/frontend/utils/chart-theme.ts
+++ b/frontend/utils/chart-theme.ts
@@ -1,0 +1,24 @@
+export const BRAND = "#7c3aed";
+export const MUTED = "#9ca3af";
+export const TEXT = "#4b5563";
+export const GRID = "rgba(209, 213, 219, 0.6)";
+export const TOOLTIP_BG = "rgba(255, 255, 255, 0.96)";
+export const TOOLTIP_BORDER = "rgba(229, 231, 235, 0.9)";
+export const FILTERED_OUT = "#d1d5db";
+
+export const tickFormatter = new Intl.DateTimeFormat("ru-RU", { day: "numeric", month: "short" });
+
+export const defaultDataZoom = [
+  {
+    type: "slider" as const,
+    height: 20,
+    bottom: 4,
+    minSpan: 5,
+    borderColor: "transparent",
+    fillerColor: "rgba(124, 58, 237, 0.08)",
+    handleStyle: { color: BRAND },
+    moveHandleStyle: { color: BRAND },
+    textStyle: { color: MUTED, fontSize: 11 }
+  },
+  { type: "inside" as const, minSpan: 5 }
+];


### PR DESCRIPTION
Closes #53: График истории монеты.

Результат:
- График строится из отдельного запроса (до 2000 точек), независимо от пагинации  таблицы
- Фильтры по цене и объему визуализируются на графике: сплошная -- в фильтре, пунктирная -- вне
- График статистики мигрирован с кастомных div на echarts (унификация с графиком монеты)
- Миграция с recharts на echarts (задел под boxplot из issue #43)
