### PR TITLE
feat: implement compare page

### DIFF
--- a/backend/src/main/java/com/cryptowatch/backend/controller/CoinsController.java
+++ b/backend/src/main/java/com/cryptowatch/backend/controller/CoinsController.java
@@ -14,10 +14,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/coins")
@@ -175,6 +177,25 @@ public class CoinsController {
     @lombok.Data
     static class AddToFavoritesRequest {
         private String symbol;
+    }
+
+    @GetMapping("/compare")
+    public ResponseEntity<CompareResponse> compareCoins(
+            @RequestHeader("Authorization") String authHeader,
+            @RequestParam String symbols,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Date from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Date to) {
+
+        String token = authHeader.substring(7);
+        jwtTokenProvider.extractUserId(token);
+
+        List<String> symbolList = Arrays.stream(symbols.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toList());
+
+        CompareResponse response = coinService.compareCoins(symbolList, from, to);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/refresh")

--- a/backend/src/main/java/com/cryptowatch/backend/dto/response/CompareResponse.java
+++ b/backend/src/main/java/com/cryptowatch/backend/dto/response/CompareResponse.java
@@ -1,0 +1,40 @@
+package com.cryptowatch.backend.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class CompareResponse {
+
+    private List<CoinData> coins;
+    private List<String> insufficientData;
+
+    @Data
+    @Builder
+    public static class CoinData {
+        private String symbol;
+        private String name;
+        private List<LinearPoint> linearSeries;
+        private BoxPlotStats boxPlot;
+    }
+
+    @Data
+    @Builder
+    public static class LinearPoint {
+        private String timestamp;
+        private double pctFromStart;
+    }
+
+    @Data
+    @Builder
+    public static class BoxPlotStats {
+        private double min;
+        private double q1;
+        private double median;
+        private double q3;
+        private double max;
+    }
+}

--- a/backend/src/main/java/com/cryptowatch/backend/service/CoinService.java
+++ b/backend/src/main/java/com/cryptowatch/backend/service/CoinService.java
@@ -4,6 +4,7 @@ import com.cryptowatch.backend.dto.common.CoinDto;
 import com.cryptowatch.backend.dto.response.AddCoinResponse;
 import com.cryptowatch.backend.dto.response.CoinDetailsResponse;
 import com.cryptowatch.backend.dto.response.CoinHistoryResponse;
+import com.cryptowatch.backend.dto.response.CompareResponse;
 import com.cryptowatch.backend.dto.response.DeleteCoinResponse;
 import com.cryptowatch.backend.dto.response.FavoritesResponse;
 import com.cryptowatch.backend.dto.response.SearchCoinsResponse;
@@ -338,6 +339,94 @@ public class CoinService {
                 .message(symbol + " добавлена в избранное")
                 .coin(coinInfo)
                 .build();
+    }
+
+    public CompareResponse compareCoins(List<String> symbols, Date from, Date to) {
+        if (symbols.size() < 2 || symbols.size() > 10) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Сравнение доступно для 2–10 монет");
+        }
+
+        List<String> upperSymbols = symbols.stream()
+                .map(String::toUpperCase)
+                .collect(Collectors.toList());
+
+        for (String s : upperSymbols) {
+            coinsMetaRepository.findBySymbol(s)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Монета " + s + " не найдена"));
+        }
+
+        Date effectiveTo = (to != null) ? to : new Date();
+        Date effectiveFrom;
+        if (from != null) {
+            effectiveFrom = from;
+        } else {
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(effectiveTo);
+            cal.add(Calendar.DAY_OF_YEAR, -7);
+            effectiveFrom = cal.getTime();
+        }
+
+        List<String> insufficientData = new ArrayList<>();
+        List<CompareResponse.CoinData> coinDataList = new ArrayList<>();
+
+        for (String s : upperSymbols) {
+            List<CoinSnapshot> snapshots = snapshotsRepository.findSnapshotsForSymbolBetweenDates(s, effectiveFrom, effectiveTo);
+            snapshots.sort(Comparator.comparing(CoinSnapshot::getTimestamp));
+            if (snapshots.size() < 2) insufficientData.add(s);
+            CoinsMeta meta = coinsMetaRepository.findBySymbol(s).orElseThrow();
+            coinDataList.add(buildCoinData(meta, snapshots));
+        }
+
+        return CompareResponse.builder()
+                .coins(coinDataList)
+                .insufficientData(insufficientData)
+                .build();
+    }
+
+    private CompareResponse.CoinData buildCoinData(CoinsMeta meta, List<CoinSnapshot> snapshots) {
+        double firstPrice = snapshots.isEmpty() ? 0.0 : snapshots.get(0).getPrice();
+
+        List<CompareResponse.LinearPoint> linearSeries = snapshots.stream()
+                .map(s -> {
+                    double pct = firstPrice == 0.0 ? 0.0 : (s.getPrice() - firstPrice) / firstPrice * 100.0;
+                    return CompareResponse.LinearPoint.builder()
+                            .timestamp(s.getTimestamp().toInstant().toString())
+                            .pctFromStart(Math.round(pct * 100.0) / 100.0)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        List<Double> prices = snapshots.stream()
+                .map(CoinSnapshot::getPrice)
+                .collect(Collectors.toList());
+
+        return CompareResponse.CoinData.builder()
+                .symbol(meta.getSymbol())
+                .name(meta.getName())
+                .linearSeries(linearSeries)
+                .boxPlot(prices.isEmpty() ? null : computeBoxPlot(prices))
+                .build();
+    }
+
+    private CompareResponse.BoxPlotStats computeBoxPlot(List<Double> prices) {
+        List<Double> sorted = new ArrayList<>(prices);
+        Collections.sort(sorted);
+        return CompareResponse.BoxPlotStats.builder()
+                .min(sorted.get(0))
+                .q1(percentile(sorted, 25))
+                .median(percentile(sorted, 50))
+                .q3(percentile(sorted, 75))
+                .max(sorted.get(sorted.size() - 1))
+                .build();
+    }
+
+    private double percentile(List<Double> sorted, double p) {
+        double index = (p / 100.0) * (sorted.size() - 1);
+        int lower = (int) Math.floor(index);
+        int upper = (int) Math.ceil(index);
+        if (lower == upper) return sorted.get(lower);
+        return sorted.get(lower) * (upper - index) + sorted.get(upper) * (index - lower);
     }
 
     public DeleteCoinResponse removeFromFavorites(String userId, String symbol) {

--- a/frontend/components/compare/compare-boxplot-chart.tsx
+++ b/frontend/components/compare/compare-boxplot-chart.tsx
@@ -1,0 +1,84 @@
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
+
+import type { CompareCoinData } from "@/types/coins";
+import { GRID, MUTED, TEXT, TOOLTIP_BG, TOOLTIP_BORDER } from "@/utils/chart-theme";
+
+const COIN_COLORS = ["#7c3aed", "#059669", "#d97706", "#dc2626", "#0891b2", "#be185d"];
+
+interface CompareBoxPlotChartProps {
+  coins: CompareCoinData[];
+}
+
+const computeBoxStats = (coin: CompareCoinData): number[] | null => {
+  if (coin.linearSeries.length < 2) return null;
+  const vals = [...coin.linearSeries.map((p) => p.pctFromStart)].sort((a, b) => a - b);
+  const n = vals.length;
+  const percentile = (p: number) => {
+    const idx = (p / 100) * (n - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    return lo === hi ? vals[lo] : vals[lo] * (hi - idx) + vals[hi] * (idx - lo);
+  };
+  return [vals[0], percentile(25), percentile(50), percentile(75), vals[n - 1]];
+};
+
+const fmtPct = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+
+export const CompareBoxPlotChart = ({ coins }: CompareBoxPlotChartProps) => {
+  const option = useMemo(() => {
+    const items = coins
+      .map((coin, i) => ({ coin, stats: computeBoxStats(coin), color: COIN_COLORS[i % COIN_COLORS.length] }))
+      .filter((x): x is { coin: CompareCoinData; stats: number[]; color: string } => x.stats !== null);
+
+    return {
+      tooltip: {
+        trigger: "item",
+        backgroundColor: TOOLTIP_BG,
+        borderColor: TOOLTIP_BORDER,
+        textStyle: { color: TEXT, fontSize: 12 },
+        formatter: (params: { name: string; value: number[] }) => {
+          const [min, q1, median, q3, max] = params.value;
+          return [
+            `<b>${params.name}</b>`,
+            `Макс: ${fmtPct(max)}`,
+            `Q3: ${fmtPct(q3)}`,
+            `Медиана: ${fmtPct(median)}`,
+            `Q1: ${fmtPct(q1)}`,
+            `Мин: ${fmtPct(min)}`
+          ].join("<br/>");
+        }
+      },
+      grid: { left: 72, right: 16, top: 16, bottom: 32 },
+      xAxis: {
+        type: "category",
+        data: items.map((x) => x.coin.symbol),
+        axisLine: { lineStyle: { color: GRID } },
+        axisLabel: { color: TEXT, fontSize: 13, fontWeight: "bold" }
+      },
+      yAxis: {
+        type: "value",
+        axisLabel: { color: MUTED, fontSize: 11, formatter: fmtPct },
+        splitLine: { lineStyle: { color: GRID } }
+      },
+      series: [
+        {
+          type: "boxplot",
+          data: items.map((x) => ({
+            value: x.stats,
+            itemStyle: { color: `${x.color}22`, borderColor: x.color, borderWidth: 2 }
+          }))
+        }
+      ]
+    };
+  }, [coins]);
+
+  return (
+    <section className="cw-surface-soft">
+      <p className="cw-kicker mb-4">Распределение изменения цены за период (Box Plot, % от старта)</p>
+      <div className="h-72 w-full">
+        <ReactECharts option={option} style={{ height: "100%", width: "100%" }} />
+      </div>
+    </section>
+  );
+};

--- a/frontend/components/compare/compare-drawer.tsx
+++ b/frontend/components/compare/compare-drawer.tsx
@@ -1,0 +1,166 @@
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { coinsService } from "@/services/coins/coins-service";
+import type { WatchlistCoin } from "@/types/coins";
+
+interface CompareDrawerProps {
+  symbol: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const CompareDrawer = ({ symbol, isOpen, onClose }: CompareDrawerProps) => {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [defaultList, setDefaultList] = useState<WatchlistCoin[]>([]);
+  const [searchResults, setSearchResults] = useState<WatchlistCoin[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    coinsService
+      .getWatchlist({ pageSize: 50 })
+      .then((r) => {
+        const sorted = [...r.coins].sort((a, b) => (b.volume24hUsd ?? 0) - (a.volume24hUsd ?? 0));
+        setDefaultList(sorted);
+      })
+      .catch(() => setDefaultList([]));
+  }, [isOpen]);
+
+  const onSearchChange = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (!query.trim()) { setSearchResults([]); return; }
+      timeoutRef.current = setTimeout(() => {
+        coinsService
+          .searchCoins({ query })
+          .then((r) => setSearchResults(r.coins.filter((c) => c.symbol !== symbol && !selected.includes(c.symbol))))
+          .catch(() => setSearchResults([]));
+      }, 300);
+    },
+    [symbol, selected]
+  );
+
+  const onAdd = useCallback((s: string) => {
+    setSelected((prev) => (prev.includes(s) ? prev : [...prev, s]));
+    setSearchQuery("");
+    setSearchResults([]);
+  }, []);
+
+  const onRemove = useCallback((s: string) => {
+    setSelected((prev) => prev.filter((x) => x !== s));
+  }, []);
+
+  const onGo = useCallback(() => {
+    const withParam = selected.join(",");
+    void router.push(`/app/compare/${symbol}${withParam ? `?with=${withParam}` : ""}`);
+    onClose();
+  }, [router, symbol, selected, onClose]);
+
+  const handleClose = useCallback(() => {
+    setSearchQuery("");
+    setSearchResults([]);
+    setSelected([]);
+    onClose();
+  }, [onClose]);
+
+  const visibleList = searchQuery.trim()
+    ? searchResults
+    : defaultList.filter((c) => c.symbol !== symbol && !selected.includes(c.symbol));
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+          onClick={handleClose}
+        />
+      )}
+
+      <div
+        className={`fixed inset-y-0 right-0 z-50 flex w-80 flex-col border-l border-border shadow-2xl transition-transform duration-300 ${
+          isOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+        style={{ background: "var(--overlay-strong)", backdropFilter: "blur(18px)" }}
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-4">
+          <div>
+            <p className="cw-kicker">Сравнение</p>
+            <p className="text-sm font-semibold" translate="no">{symbol}</p>
+          </div>
+          <button
+            type="button"
+            className="cw-button-secondary px-2 py-1 text-base"
+            onClick={handleClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+          {selected.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {selected.map((s) => (
+                <span key={s} className="flex items-center gap-1 rounded-full border border-border bg-accent px-3 py-1 text-sm">
+                  <span translate="no">{s}</span>
+                  <button
+                    type="button"
+                    className="ml-1 text-muted-foreground hover:text-foreground"
+                    onClick={() => onRemove(s)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <input
+            className="cw-input w-full"
+            placeholder="Поиск тикера..."
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && visibleList.length > 0) {
+                e.preventDefault();
+                onAdd(visibleList[0].symbol);
+              }
+            }}
+            autoComplete="off"
+          />
+
+          {visibleList.length > 0 && (
+            <ul className="flex flex-col gap-0.5">
+              {visibleList.slice(0, 12).map((coin) => (
+                <li key={coin.symbol}>
+                  <button
+                    type="button"
+                    className="w-full rounded-md px-3 py-2 text-left text-sm hover:bg-accent"
+                    onClick={() => onAdd(coin.symbol)}
+                  >
+                    <span className="font-medium" translate="no">{coin.symbol}</span>
+                    <span className="ml-2 text-muted-foreground">{coin.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="border-t border-border p-4">
+          <button
+            type="button"
+            className="cw-button-primary w-full"
+            disabled={selected.length === 0}
+            onClick={onGo}
+          >
+            Перейти к сравнению
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/frontend/components/compare/compare-linear-chart.tsx
+++ b/frontend/components/compare/compare-linear-chart.tsx
@@ -1,0 +1,81 @@
+import ReactECharts from "echarts-for-react";
+import { useMemo } from "react";
+
+import type { CompareCoinData } from "@/types/coins";
+import {
+  GRID,
+  MUTED,
+  TEXT,
+  TOOLTIP_BG,
+  TOOLTIP_BORDER,
+  defaultDataZoom,
+  tickFormatter
+} from "@/utils/chart-theme";
+
+const COIN_COLORS = ["#7c3aed", "#059669", "#d97706", "#dc2626", "#0891b2", "#be185d"];
+
+interface CompareLinearChartProps {
+  coins: CompareCoinData[];
+}
+
+export const CompareLinearChart = ({ coins }: CompareLinearChartProps) => {
+  const option = useMemo(
+    () => ({
+      tooltip: {
+        trigger: "axis",
+        backgroundColor: TOOLTIP_BG,
+        borderColor: TOOLTIP_BORDER,
+        textStyle: { color: TEXT, fontSize: 12 },
+        formatter: (params: { seriesName: string; value: [number, number]; color: string }[]) => {
+          const date = tickFormatter.format(new Date(params[0].value[0]));
+          const lines = params
+            .map((s) => {
+              const sign = s.value[1] >= 0 ? "+" : "";
+              return `<span style="color:${s.color}">●</span> ${s.seriesName}: ${sign}${s.value[1].toFixed(2)}%`;
+            })
+            .join("<br/>");
+          return `${lines}<br/><small style="color:${MUTED}">${date}</small>`;
+        }
+      },
+      legend: { data: coins.map((c) => c.symbol), textStyle: { color: TEXT, fontSize: 12 }, top: 0 },
+      grid: { left: 60, right: 16, top: 36, bottom: 48 },
+      xAxis: {
+        type: "time",
+        axisLine: { lineStyle: { color: GRID } },
+        axisLabel: { color: MUTED, fontSize: 11, formatter: (v: number) => tickFormatter.format(new Date(v)) }
+      },
+      yAxis: {
+        type: "value",
+        axisLabel: {
+          color: MUTED,
+          fontSize: 11,
+          formatter: (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(1)}%`
+        },
+        splitLine: { lineStyle: { color: GRID } }
+      },
+      dataZoom: defaultDataZoom,
+      series: coins.map((coin, i) => ({
+        name: coin.symbol,
+        type: "line",
+        data: coin.linearSeries.map((p) => [new Date(p.timestamp).getTime(), p.pctFromStart]),
+        smooth: true,
+        symbol: "none",
+        lineStyle: { color: COIN_COLORS[i % COIN_COLORS.length], width: 2 },
+        itemStyle: { color: COIN_COLORS[i % COIN_COLORS.length] }
+      }))
+    }),
+    [coins]
+  );
+
+  return (
+    <section className="cw-surface-soft">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <p className="cw-kicker">Динамика цены (% от начала периода)</p>
+        <p className="text-xs text-muted-foreground">Клик по монете в легенде — скрыть/показать</p>
+      </div>
+      <div className="h-80 w-full">
+        <ReactECharts option={option} style={{ height: "100%", width: "100%" }} />
+      </div>
+    </section>
+  );
+};

--- a/frontend/hooks/compare-view/compare-view-types.ts
+++ b/frontend/hooks/compare-view/compare-view-types.ts
@@ -1,0 +1,29 @@
+import type { CompareResponse, WatchlistCoin } from "@/types/coins";
+
+export type CompareViewStatus = "idle" | "loading" | "ready" | "error";
+export type CompareDatePreset = "7d" | "30d" | "90d";
+
+export interface UseCompareViewResult {
+  symbol1: string;
+  extraSymbols: string[];
+  searchQuery: string;
+  searchResults: WatchlistCoin[];
+  isSearching: boolean;
+  datePreset: CompareDatePreset | null;
+  dateFrom: string;
+  dateTo: string;
+  status: CompareViewStatus;
+  compareData: CompareResponse | null;
+  errorMessage: string;
+  canCompare: boolean;
+  headTitle: string;
+  pageTitle: string;
+  onSearchQueryChange: (query: string) => void;
+  onAddSymbol: (symbol: string) => void;
+  onRemoveSymbol: (symbol: string) => void;
+  onDatePresetChange: (preset: CompareDatePreset) => void;
+  onDateFromChange: (date: string) => void;
+  onDateToChange: (date: string) => void;
+  onCompare: () => Promise<void>;
+  goBack: () => void;
+}

--- a/frontend/hooks/compare-view/use-compare-view.ts
+++ b/frontend/hooks/compare-view/use-compare-view.ts
@@ -1,0 +1,175 @@
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { CompareDatePreset, UseCompareViewResult } from "@/hooks/compare-view/compare-view-types";
+import { coinsService } from "@/services/coins/coins-service";
+import type { CompareResponse, WatchlistCoin } from "@/types/coins";
+import { getApiErrorMessage } from "@/utils/error-message";
+
+const toIso = (d: Date): string => d.toISOString();
+
+const presetDates = (preset: CompareDatePreset): { from: string; to: string } => {
+  const to = new Date();
+  const from = new Date(to);
+  const days = preset === "7d" ? 7 : preset === "30d" ? 30 : 90;
+  from.setDate(from.getDate() - days);
+  return { from: toIso(from), to: toIso(to) };
+};
+
+const defaultFrom = (): string => {
+  const d = new Date();
+  d.setDate(d.getDate() - 7);
+  return toIso(d);
+};
+
+const getSymbolFromQuery = (q: unknown): string => {
+  if (typeof q === "string") return q.toUpperCase();
+  if (Array.isArray(q) && typeof q[0] === "string") return (q[0] as string).toUpperCase();
+  return "";
+};
+
+export const useCompareView = (): UseCompareViewResult => {
+  const router = useRouter();
+  const symbol1 = getSymbolFromQuery(router.query.symbol);
+
+  const [extraSymbols, setExtraSymbols] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<WatchlistCoin[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [datePreset, setDatePreset] = useState<CompareDatePreset | null>("7d");
+  const [dateFrom, setDateFrom] = useState(defaultFrom);
+  const [dateTo, setDateTo] = useState(() => toIso(new Date()));
+  const [status, setStatus] = useState<UseCompareViewResult["status"]>("idle");
+  const [compareData, setCompareData] = useState<CompareResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [prePopulated, setPrePopulated] = useState(false);
+
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!router.isReady || prePopulated) return;
+    const withParam = router.query.with;
+    if (withParam) {
+      const raw = Array.isArray(withParam) ? withParam[0] : withParam;
+      const preSelected = raw
+        .split(",")
+        .map((s) => s.trim().toUpperCase())
+        .filter((s) => s && s !== symbol1);
+      if (preSelected.length > 0) setExtraSymbols(preSelected);
+    }
+    setPrePopulated(true);
+  }, [router.isReady, prePopulated, router.query.with, symbol1]);
+
+  const onSearchQueryChange = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+      if (!query.trim()) {
+        setSearchResults([]);
+        return;
+      }
+      searchTimeoutRef.current = setTimeout(() => {
+        setIsSearching(true);
+        coinsService
+          .searchCoins({ query })
+          .then((result) => {
+            setSearchResults(result.coins.filter((c) => c.symbol !== symbol1));
+          })
+          .catch(() => {
+            setSearchResults([]);
+          })
+          .finally(() => {
+            setIsSearching(false);
+          });
+      }, 300);
+    },
+    [symbol1]
+  );
+
+  const onAddSymbol = useCallback((symbol: string) => {
+    setExtraSymbols((prev) => (prev.includes(symbol) ? prev : [...prev, symbol]));
+    setSearchQuery("");
+    setSearchResults([]);
+  }, []);
+
+  const onRemoveSymbol = useCallback((symbol: string) => {
+    setExtraSymbols((prev) => prev.filter((s) => s !== symbol));
+  }, []);
+
+  const onDatePresetChange = useCallback((preset: CompareDatePreset) => {
+    const { from, to } = presetDates(preset);
+    setDatePreset(preset);
+    setDateFrom(from);
+    setDateTo(to);
+  }, []);
+
+  const onDateFromChange = useCallback((date: string) => {
+    setDateFrom(date);
+    setDatePreset(null);
+  }, []);
+
+  const onDateToChange = useCallback((date: string) => {
+    setDateTo(date);
+    setDatePreset(null);
+  }, []);
+
+  const onCompare = useCallback(async () => {
+    if (!symbol1 || extraSymbols.length === 0) return;
+    setStatus("loading");
+    setCompareData(null);
+    setErrorMessage("");
+    try {
+      const data = await coinsService.compareCoins({
+        symbols: [symbol1, ...extraSymbols],
+        from: dateFrom,
+        to: dateTo
+      });
+      setCompareData(data);
+      setStatus("ready");
+    } catch (error) {
+      setErrorMessage(getApiErrorMessage(error, "Не удалось выполнить сравнение"));
+      setStatus("error");
+    }
+  }, [symbol1, extraSymbols, dateFrom, dateTo]);
+
+  const goBack = useCallback(() => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      void router.push("/app");
+    }
+  }, [router]);
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    };
+  }, []);
+
+  const titlePart = extraSymbols.length > 0 ? `${symbol1} vs ${extraSymbols.join(", ")}` : symbol1;
+
+  return {
+    symbol1,
+    extraSymbols,
+    searchQuery,
+    searchResults,
+    isSearching,
+    datePreset,
+    dateFrom,
+    dateTo,
+    status,
+    compareData,
+    errorMessage,
+    canCompare: Boolean(symbol1 && extraSymbols.length > 0),
+    headTitle: `Сравнение ${titlePart} | CryptoWatch`,
+    pageTitle: `Сравнение: ${titlePart}`,
+    onSearchQueryChange,
+    onAddSymbol,
+    onRemoveSymbol,
+    onDatePresetChange,
+    onDateFromChange,
+    onDateToChange,
+    onCompare,
+    goBack
+  };
+};

--- a/frontend/pages/app/coins/[symbol].tsx
+++ b/frontend/pages/app/coins/[symbol].tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
+
 import { AppPageShell } from "@/components/app-page-shell";
+import { CompareDrawer } from "@/components/compare/compare-drawer";
 import { CoinHistorySection } from "@/components/coin-details/coin-history-section";
 import { CoinSummaryCard } from "@/components/coin-details/coin-summary-card";
 import { EmptyState } from "@/components/view-state/empty-state";
@@ -10,6 +13,7 @@ import { useCoinDetailsView } from "@/hooks/coin-details-view/use-coin-details-v
 export default function CoinDetailsPage() {
   const viewState = useCoinDetailsView();
   const historyViewState = useCoinHistoryView();
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const symbolLabel = viewState.symbol || "...";
 
   return (
@@ -20,11 +24,30 @@ export default function CoinDetailsPage() {
       title={viewState.pageTitle}
       description={viewState.pageDescription}
     >
+      {viewState.symbol && (
+        <CompareDrawer
+          symbol={viewState.symbol}
+          isOpen={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+        />
+      )}
+
       <section className="mt-8 space-y-6">
         <div className="flex items-center justify-between gap-3">
-          <button className="cw-button-secondary" type="button" onClick={viewState.goBack}>
-            Назад
-          </button>
+          <div className="flex items-center gap-2">
+            <button className="cw-button-secondary" type="button" onClick={viewState.goBack}>
+              Назад
+            </button>
+            {viewState.status === "ready" && viewState.symbol && (
+              <button
+                className="cw-button-primary"
+                type="button"
+                onClick={() => setDrawerOpen(true)}
+              >
+                Сравнить
+              </button>
+            )}
+          </div>
 
           <span className="cw-auth-badge" translate="no">
             {symbolLabel}

--- a/frontend/pages/app/compare/[symbol].tsx
+++ b/frontend/pages/app/compare/[symbol].tsx
@@ -1,0 +1,163 @@
+import { AppPageShell } from "@/components/app-page-shell";
+import { CompareBoxPlotChart } from "@/components/compare/compare-boxplot-chart";
+import { CompareLinearChart } from "@/components/compare/compare-linear-chart";
+import { ErrorState } from "@/components/view-state/error-state";
+import { LoadingState } from "@/components/view-state/loading-state";
+import type { CompareDatePreset } from "@/hooks/compare-view/compare-view-types";
+import { useCompareView } from "@/hooks/compare-view/use-compare-view";
+
+const DATE_PRESETS: { label: string; value: CompareDatePreset }[] = [
+  { label: "7д", value: "7d" },
+  { label: "30д", value: "30d" },
+  { label: "90д", value: "90d" }
+];
+
+export default function ComparePage() {
+  const v = useCompareView();
+
+  return (
+    <AppPageShell
+      activeSection="coins"
+      headTitle={v.headTitle}
+      headDescription="Сравнение динамики цен монет"
+      title={v.pageTitle}
+      description="Линейный график и box plot за выбранный период"
+    >
+      <section className="mt-8 space-y-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <button className="cw-button-secondary" type="button" onClick={v.goBack}>
+            Назад
+          </button>
+          <span className="cw-auth-badge" translate="no">{v.symbol1}</span>
+          {v.extraSymbols.map((s) => (
+            <span key={s} className="flex items-center gap-1">
+              <span className="text-muted-foreground">vs</span>
+              <span className="cw-auth-badge" translate="no">{s}</span>
+            </span>
+          ))}
+        </div>
+
+        <form
+          className="cw-surface-soft space-y-4"
+          onSubmit={(e) => { e.preventDefault(); if (v.canCompare && v.status !== "loading") void v.onCompare(); }}
+        >
+          <div className="flex flex-col gap-1">
+            <label className="cw-kicker">Добавить монету</label>
+            {v.extraSymbols.length > 0 && (
+              <div className="flex flex-wrap gap-2 mb-2">
+                {v.extraSymbols.map((s) => (
+                  <span key={s} className="flex items-center gap-1 rounded-full border border-border bg-accent px-3 py-1 text-sm">
+                    <span translate="no">{s}</span>
+                    <button
+                      type="button"
+                      className="ml-1 text-muted-foreground hover:text-foreground"
+                      onClick={() => v.onRemoveSymbol(s)}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="relative">
+              <input
+                className="cw-input w-full"
+                placeholder="Введите тикер (например, ETH)"
+                value={v.searchQuery}
+                onChange={(e) => v.onSearchQueryChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && v.searchResults.length > 0) {
+                    e.preventDefault();
+                    v.onAddSymbol(v.searchResults[0].symbol);
+                  }
+                }}
+                autoComplete="off"
+              />
+              {v.searchResults.length > 0 && (
+                <ul className="absolute z-50 mt-1 w-full rounded-md border border-border bg-background shadow-md">
+                  {v.searchResults.slice(0, 8).map((coin) => (
+                    <li key={coin.symbol}>
+                      <button
+                        type="button"
+                        className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
+                        onClick={() => v.onAddSymbol(coin.symbol)}
+                      >
+                        <span className="font-medium" translate="no">{coin.symbol}</span>
+                        <span className="ml-2 text-muted-foreground">{coin.name}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="cw-kicker">Период</label>
+            <div className="flex flex-wrap items-center gap-2">
+              {DATE_PRESETS.map((p) => (
+                <button
+                  key={p.value}
+                  type="button"
+                  className={v.datePreset === p.value ? "cw-button-primary" : "cw-button-secondary"}
+                  onClick={() => v.onDatePresetChange(p.value)}
+                >
+                  {p.label}
+                </button>
+              ))}
+              <input
+                type="date"
+                className="cw-input"
+                value={v.dateFrom.slice(0, 10)}
+                onChange={(e) => v.onDateFromChange(`${e.target.value}T00:00:00.000Z`)}
+              />
+              <span className="text-muted-foreground">—</span>
+              <input
+                type="date"
+                className="cw-input"
+                value={v.dateTo.slice(0, 10)}
+                onChange={(e) => v.onDateToChange(`${e.target.value}T23:59:59.999Z`)}
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="cw-button-primary"
+            disabled={!v.canCompare || v.status === "loading"}
+          >
+            {v.status === "loading" ? "Загрузка..." : "Построить"}
+          </button>
+        </form>
+
+        {v.status === "loading" && (
+          <LoadingState title="Загружаем данные..." message="Сравниваем монеты за выбранный период" />
+        )}
+
+        {v.status === "error" && (
+          <ErrorState
+            title="Не удалось выполнить сравнение"
+            message={v.errorMessage}
+            onAction={() => {
+              void v.onCompare();
+            }}
+          />
+        )}
+
+        {v.status === "ready" && v.compareData && (
+          <div className="space-y-6">
+            {v.compareData.insufficientData.length > 0 && (
+              <p className="text-sm text-amber-600">
+                Недостаточно данных для: {v.compareData.insufficientData.join(", ")}
+              </p>
+            )}
+            <CompareLinearChart coins={v.compareData.coins} />
+            {v.compareData.coins.some((c) => c.boxPlot !== null) && (
+              <CompareBoxPlotChart coins={v.compareData.coins} />
+            )}
+          </div>
+        )}
+      </section>
+    </AppPageShell>
+  );
+}

--- a/frontend/services/coins/backend-coins-normalizer.ts
+++ b/frontend/services/coins/backend-coins-normalizer.ts
@@ -7,6 +7,9 @@ import type {
   CoinHistoryEntry,
   CoinHistoryResponse,
   CoinsMutationResponse,
+  CompareBoxPlot,
+  CompareCoinData,
+  CompareResponse,
   FavoritesResponse,
   PaginatedCoinsResponse,
   RefreshWatchlistResponse,
@@ -359,5 +362,45 @@ export const normalizeCoinHistoryResponse = (payload: unknown): CoinHistoryRespo
     history: rawHistory.map(normalizeCoinHistoryEntry),
     totalCount: parseRequiredNumber(payload.totalCount, "totalCount"),
     dateRange: normalizeCoinHistoryDateRange(payload.dateRange)
+  };
+};
+
+const normalizeCompareBoxPlot = (payload: unknown): CompareBoxPlot => {
+  if (!isRecord(payload)) throw createShapeError("boxPlot");
+  return {
+    min: parseRequiredNumber(payload.min, "boxPlot.min"),
+    q1: parseRequiredNumber(payload.q1, "boxPlot.q1"),
+    median: parseRequiredNumber(payload.median, "boxPlot.median"),
+    q3: parseRequiredNumber(payload.q3, "boxPlot.q3"),
+    max: parseRequiredNumber(payload.max, "boxPlot.max")
+  };
+};
+
+const normalizeCompareCoinData = (payload: unknown): CompareCoinData => {
+  if (!isRecord(payload)) throw createShapeError("coinData");
+  const rawSeries = payload.linearSeries;
+  if (!Array.isArray(rawSeries)) throw createShapeError("linearSeries");
+  return {
+    symbol: parseRequiredString(payload.symbol, "coinData.symbol"),
+    name: parseString(payload.name) ?? parseRequiredString(payload.symbol, "coinData.symbol"),
+    linearSeries: rawSeries.map((p) => {
+      if (!isRecord(p)) throw createShapeError("linearPoint");
+      return {
+        timestamp: parseRequiredIsoDateString(p.timestamp, "linearPoint.timestamp"),
+        pctFromStart: parseRequiredNumber(p.pctFromStart, "linearPoint.pctFromStart")
+      };
+    }),
+    boxPlot: payload.boxPlot == null ? null : normalizeCompareBoxPlot(payload.boxPlot)
+  };
+};
+
+export const normalizeCompareResponse = (payload: unknown): CompareResponse => {
+  if (!isRecord(payload)) throw createShapeError("compareResponse");
+  if (!Array.isArray(payload.coins)) throw createShapeError("compareResponse.coins");
+  return {
+    coins: payload.coins.map(normalizeCompareCoinData),
+    insufficientData: Array.isArray(payload.insufficientData)
+      ? (payload.insufficientData as unknown[]).filter((s): s is string => typeof s === "string")
+      : []
   };
 };

--- a/frontend/services/coins/backend-coins-service.ts
+++ b/frontend/services/coins/backend-coins-service.ts
@@ -4,6 +4,7 @@ import {
   normalizeCoinDetailsResponse,
   normalizeCoinHistoryResponse,
   normalizeCoinsMutationResponse,
+  normalizeCompareResponse,
   normalizeFavoritesResponse,
   normalizeRefreshWatchlistResponse,
   normalizeSearchCoinsResponse,
@@ -17,6 +18,7 @@ import {
 import type {
   CoinHistoryRequestParams,
   CoinsApi,
+  CompareRequestParams,
   FavoritesRequestParams,
   SearchCoinsRequestParams,
   WatchlistRequestParams
@@ -93,5 +95,16 @@ export const backendCoinsService: CoinsApi = {
     );
 
     return normalizeCoinsMutationResponse(response);
+  },
+  async compareCoins(params: CompareRequestParams) {
+    const response = await authorizedHttpClient.get<unknown>("/api/coins/compare", {
+      params: {
+        symbols: params.symbols.join(","),
+        from: params.from,
+        to: params.to
+      }
+    });
+
+    return normalizeCompareResponse(response);
   }
 };

--- a/frontend/types/coins.ts
+++ b/frontend/types/coins.ts
@@ -151,6 +151,37 @@ export interface WatchlistRequestParams {
   pageNo?: number;
 }
 
+export interface CompareLinearPoint {
+  timestamp: string;
+  pctFromStart: number;
+}
+
+export interface CompareBoxPlot {
+  min: number;
+  q1: number;
+  median: number;
+  q3: number;
+  max: number;
+}
+
+export interface CompareCoinData {
+  symbol: string;
+  name: string;
+  linearSeries: CompareLinearPoint[];
+  boxPlot: CompareBoxPlot | null;
+}
+
+export interface CompareResponse {
+  coins: CompareCoinData[];
+  insufficientData: string[];
+}
+
+export interface CompareRequestParams {
+  symbols: string[];
+  from: string;
+  to: string;
+}
+
 export interface CoinsApi {
   getWatchlist(params?: WatchlistRequestParams): Promise<PaginatedCoinsResponse>;
   getFavorites(params?: FavoritesRequestParams): Promise<FavoritesResponse>;
@@ -162,4 +193,5 @@ export interface CoinsApi {
   addFavorite(symbol: string): Promise<CoinsMutationResponse>;
   removeFavorite(symbol: string): Promise<CoinsMutationResponse>;
   removeFromWatchlist(symbol: string): Promise<CoinsMutationResponse>;
+  compareCoins(params: CompareRequestParams): Promise<CompareResponse>;
 }


### PR DESCRIPTION
Closes #43: Сравнение монет и график box plot.

**Результаты:**
- Реализовано построение линейного графика и графика box plot для произвольного числа монет (2-10)
- Box plot считается в % от старта периода -- все монеты на одной шкале независимо от абсолютной цены (BTC vs SOL не давят друг друга)
- Мультимонетное сравнение вместо фиксированной пары: контракт symbols=BTC,ETH,SOL вместо symbol1/symbol2, бекенд валидирует диапазон 2-10