### PR TITLE
fix: network requests

### DIFF
--- a/frontend/hooks/import-export-view/use-import-export-view.ts
+++ b/frontend/hooks/import-export-view/use-import-export-view.ts
@@ -5,7 +5,7 @@ import { adminService } from "@/services/admin";
 import type { ImportResult } from "@/types/admin";
 import { getApiErrorMessage } from "@/utils/error-message";
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 type OperationStatus = "idle" | "loading" | "success" | "error";
 
@@ -107,7 +107,7 @@ export const useImportExportView = (): UseImportExportViewResult => {
     }
 
     if (file.size > MAX_FILE_SIZE) {
-      setFileError("Размер файла не должен превышать 10 МБ");
+      setFileError("Размер файла не должен превышать 50 МБ");
       setSelectedFile(null);
       return;
     }

--- a/frontend/hooks/watchlist-view/use-watchlist-view.ts
+++ b/frontend/hooks/watchlist-view/use-watchlist-view.ts
@@ -37,7 +37,7 @@ export const useWatchlistView = (): UseWatchlistViewResult => {
     routeState.requestParams.pageSize ?? WATCHLIST_ROUTE_STATE_CONFIG.defaultPageSize;
 
   const loadWatchlistPage = useCallback(
-    (params: WatchlistRequestParams) => coinsService.getWatchlist({pageSize: params.pageSize, pageNo: params.pageNo}),
+    (params: WatchlistRequestParams) => coinsService.getWatchlist(params),
     []
   );
 

--- a/frontend/services/coins/backend-coins-normalizer.ts
+++ b/frontend/services/coins/backend-coins-normalizer.ts
@@ -233,29 +233,15 @@ export const normalizeFavoritesResponse = (payload: unknown): FavoritesResponse 
   };
 };
 
-export const normalizeWatchlistResponse = (
-  payload: unknown,
-  requestedPageNo?: number,
-  requestedPageSize?: number
-): PaginatedCoinsResponse => {
-  if (!isRecord(payload)) {
-    throw createShapeError("payload");
-  }
-
-  const rawCoins = payload.coins;
-
-  if (!Array.isArray(rawCoins)) {
-    throw createShapeError("coins");
-  }
-
-  const coins = rawCoins.map(normalizeCoin);
+export const normalizeWatchlistResponse = (payload: unknown): PaginatedCoinsResponse => {
+  const normalized = normalizeCoinCollectionPayload(payload);
 
   return {
-    coins,
-    totalCount: parseRequiredNumber(payload.totalCount, "totalCount"),
-    hasMore: parseRequiredBoolean(payload.hasMore, "hasMore"),
-    pageNo: parseNumber(payload.pageNo) ?? requestedPageNo ?? 0,
-    pageSize: parseNumber(payload.pageSize) ?? requestedPageSize ?? coins.length
+    coins: normalized.coins,
+    totalCount: normalized.totalCount,
+    pageNo: normalized.pageNo,
+    pageSize: normalized.pageSize,
+    hasMore: normalized.hasMore
   };
 };
 

--- a/frontend/services/coins/backend-coins-service.ts
+++ b/frontend/services/coins/backend-coins-service.ts
@@ -13,7 +13,8 @@ import {
 import {
   buildCoinHistoryQueryParams,
   buildFavoritesQueryParams,
-  buildSearchCoinsQueryParams
+  buildSearchCoinsQueryParams,
+  buildWatchlistQueryParams
 } from "@/services/coins/coins-service-helpers";
 import type {
   CoinHistoryRequestParams,
@@ -27,10 +28,10 @@ import type {
 export const backendCoinsService: CoinsApi = {
   async getWatchlist(params?: WatchlistRequestParams) {
     const response = await authorizedHttpClient.get<unknown>("/api/coins/watchlist", {
-      params: params ? { pageSize: params.pageSize, pageNo: params.pageNo } : undefined
+      params: buildWatchlistQueryParams(params)
     });
 
-    return normalizeWatchlistResponse(response, params?.pageNo, params?.pageSize);
+    return normalizeWatchlistResponse(response);
   },
   async getFavorites(params?: FavoritesRequestParams) {
     const response = await authorizedHttpClient.get<unknown>("/api/coins/favorites", {

--- a/frontend/services/coins/coins-service-helpers.ts
+++ b/frontend/services/coins/coins-service-helpers.ts
@@ -3,7 +3,8 @@ import type {
   CoinHistoryRequestParams,
   CoinHistorySortKey,
   FavoritesRequestParams,
-  SearchCoinsRequestParams
+  SearchCoinsRequestParams,
+  WatchlistRequestParams
 } from "@/types/coins";
 import { getBackendCoinSortKey } from "@/utils/coin-table-sorting";
 
@@ -45,6 +46,10 @@ const buildCoinCollectionQueryParams = (
 
 export const buildFavoritesQueryParams = (
   params?: FavoritesRequestParams
+): QueryParams | undefined => buildCoinCollectionQueryParams(params);
+
+export const buildWatchlistQueryParams = (
+  params?: WatchlistRequestParams
 ): QueryParams | undefined => buildCoinCollectionQueryParams(params);
 
 export const buildSearchCoinsQueryParams = (

--- a/frontend/types/coins.ts
+++ b/frontend/types/coins.ts
@@ -146,10 +146,7 @@ export interface CoinsMutationResponse {
   message?: string;
 }
 
-export interface WatchlistRequestParams {
-  pageSize?: number;
-  pageNo?: number;
-}
+export interface WatchlistRequestParams extends CoinCollectionRequestParams {}
 
 export interface CompareLinearPoint {
   timestamp: string;


### PR DESCRIPTION
Результаты исправлений:
- Фильтры (цена, капитализация и др.) теперь реально уходят в запрос к /api/coins/watchlist -- раньше обрезалось до pageSize/pageNo
- Кнопка "Обновить" теперь тоже учитывает активные фильтры
- Лимит файла при импорте: 10 МБ --> 50 МБ